### PR TITLE
enabled keyboard status to show key solution state

### DIFF
--- a/components/keyboard/Keyboard.js
+++ b/components/keyboard/Keyboard.js
@@ -8,8 +8,9 @@ export default function Keyboard({
     onEnter,
     guesses,
     locale = "en",
+    solution,
 }) {
-    const charStatuses = getStatuses(guesses);
+    const charStatuses = getStatuses(guesses, solution);
 
     const onClick = (value) => {
         if (value === "ENTER") {

--- a/pages/battles/[battleId]/index.js
+++ b/pages/battles/[battleId]/index.js
@@ -326,6 +326,7 @@ export default function Battle() {
                             onEnter={onEnter}
                             guesses={guesses}
                             locale={battle.language}
+                            solution={battle?.solution || ""}
                         />
                     )}
 


### PR DESCRIPTION
Seems most of the work was in place to enable the keyboard to reflect the status of each letter in the guess history. This just connects the keyboard to the solution.